### PR TITLE
Update configurations.lua

### DIFF
--- a/xiaomi-switch/src/configurations.lua
+++ b/xiaomi-switch/src/configurations.lua
@@ -9,7 +9,7 @@ local devices = {
     },
     CONFIGS = {
       first_button_ep = 0x0004,
-      supported_button_values = {"pushed", "held", "pushed_2x", "pushed_3x", "pushed_4x", "pushed_5x"}
+      supported_button_values = {"pushed", "pushed_2x", "pushed_3x", "pushed_4x"}
     }
   },
   WXKG11LM_2 = {
@@ -18,7 +18,7 @@ local devices = {
     },
     CONFIGS = {
       first_button_ep = 0x0001,
-      supported_button_values = {"pushed", "held", "pushed_2x", "pushed_3x", "pushed_4x", "pushed_5x"}
+      supported_button_values = {"pushed", "held", "pushed_2x"}
     }
   },
   GROUP1 = {


### PR DESCRIPTION
Changed supported_button_values for lumi.remote.b1acn01 and lumi.sensor_switch.aq2 according to official support via https://zigbee.blakadder.com/Aqara_WXKG11LM.html.

"lumi.sensor_switch.aq2"
PREVIOUS supported_button_values = {"pushed", "held", "pushed_2x", "pushed_3x", "pushed_4x", "pushed_5x"}
    }
  },

"lumi.sensor_switch.aq2"
NEW supported_button_values = {"pushed", "pushed_2x", "pushed_3x", "pushed_4x"}
    }
  },


"lumi.remote.b1acn01"
PREVIOUS supported_button_values = {"pushed", "held", "pushed_2x", "pushed_3x", "pushed_4x", "pushed_5x"}
    }
  },

"lumi.remote.b1acn01"
NEW supported_button_values = {"pushed", "held", "pushed_2x"}
    }
  },